### PR TITLE
Azure DevOps: lineStartColumn & lineEndColumn addition

### DIFF
--- a/source/GitWebLinks/Commands/CopyLinkToCurrentFileCommand.vb
+++ b/source/GitWebLinks/Commands/CopyLinkToCurrentFileCommand.vb
@@ -36,7 +36,6 @@ Public Class CopyLinkToCurrentFileCommand
                 Dim lineSelection As LineSelection
                 Dim url As String
 
-
                 If id.Equals(Commands.CopyLinkToCurrentFile) Then
                     textSelection = Nothing
                 Else
@@ -44,10 +43,12 @@ Public Class CopyLinkToCurrentFileCommand
                 End If
 
                 If textSelection IsNot Nothing Then
-                    lineSelection = New LineSelection(textSelection.TopLine, textSelection.BottomLine)
+                    lineSelection = New LineSelection(textSelection.TopLine, textSelection.BottomLine, If(textSelection.TopPoint Is Nothing, 0, textSelection.TopPoint.DisplayColumn), If(textSelection.BottomPoint Is Nothing, 0, textSelection.BottomPoint.DisplayColumn))
                 Else
                     lineSelection = Nothing
                 End If
+
+
 
                 url = LinkInfo.Handler.MakeUrl(LinkInfo.GitInfo, filePath, lineSelection)
 

--- a/source/GitWebLinks/Commands/CopyLinkToCurrentFileCommand.vb
+++ b/source/GitWebLinks/Commands/CopyLinkToCurrentFileCommand.vb
@@ -36,6 +36,7 @@ Public Class CopyLinkToCurrentFileCommand
                 Dim lineSelection As LineSelection
                 Dim url As String
 
+
                 If id.Equals(Commands.CopyLinkToCurrentFile) Then
                     textSelection = Nothing
                 Else
@@ -43,12 +44,16 @@ Public Class CopyLinkToCurrentFileCommand
                 End If
 
                 If textSelection IsNot Nothing Then
-                    lineSelection = New LineSelection(textSelection.TopLine, textSelection.BottomLine, If(textSelection.TopPoint Is Nothing, 0, textSelection.TopPoint.DisplayColumn), If(textSelection.BottomPoint Is Nothing, 0, textSelection.BottomPoint.DisplayColumn))
+                    lineSelection = New LineSelection(
+                        textSelection.TopLine,
+                        textSelection.BottomLine,
+                        textSelection.TopPoint.DisplayColumn,
+                        textSelection.BottomPoint.DisplayColumn
+                    )
+
                 Else
                     lineSelection = Nothing
                 End If
-
-
 
                 url = LinkInfo.Handler.MakeUrl(LinkInfo.GitInfo, filePath, lineSelection)
 

--- a/source/GitWebLinks/Links/Handlers/AzureDevOpsHandler.vb
+++ b/source/GitWebLinks/Links/Handlers/AzureDevOpsHandler.vb
@@ -85,7 +85,7 @@ Public Class AzureDevOpsHandler
         Dim args As String
 
 
-        args = $"&line={selection.StartLineNumber}"
+        args = $"&line={selection.StartLineNumber}&lineStartColumn={selection.StartColumnNumber}&lineEndColumn={selection.EndColumnNumber}"
 
         If selection.StartLineNumber <> selection.EndLineNumber Then
             args &= $"&lineEnd={selection.EndLineNumber}"

--- a/source/GitWebLinks/Links/Handlers/AzureDevOpsHandler.vb
+++ b/source/GitWebLinks/Links/Handlers/AzureDevOpsHandler.vb
@@ -85,10 +85,33 @@ Public Class AzureDevOpsHandler
         Dim args As String
 
 
-        args = $"&line={selection.StartLineNumber}&lineStartColumn={selection.StartColumnNumber}&lineEndColumn={selection.EndColumnNumber}"
+        args = $"&line={selection.StartLineNumber}"
 
         If selection.StartLineNumber <> selection.EndLineNumber Then
+            ' The selection spans multiple lines. Add the end line number.
             args &= $"&lineEnd={selection.EndLineNumber}"
+
+            ' Multi-line selections always need to specify the start
+            ' and end columns, otherwise nothing ends up being selected.
+            args &= $"&lineStartColumn={selection.StartColumnNumber}&lineEndColumn={selection.EndColumnNumber}"
+
+        Else
+            ' If the single-line selection is an actual selection as opposed to the caret
+            ' being somewhere on the line but not actually selecting any text, then we will
+            ' include that same selection range in the link. If there is no selected text, then
+            ' we'll leave the start and end columns out. If we include them when they are the same
+            ' value, Azure DevOps will still scroll to the line, but the line won't be highlighted.
+            If selection.StartColumnNumber <> selection.EndColumnNumber Then
+                args &= $"&lineStartColumn={selection.StartColumnNumber}&lineEndColumn={selection.EndColumnNumber}"
+
+            Else
+                ' The modern repository landing page in Azure DevOps won't highlight
+                ' any text if we only provide a start line number. We also need to include
+                ' the start column and end column. Since there is no actual text selected,
+                ' we will select the whole line by setting the end line number to the next
+                ' line and the start and end columns to the start of each line.
+                args &= $"&lineEnd={selection.StartLineNumber + 1}&lineStartColumn=1&lineEndColumn=1"
+            End If
         End If
 
         Return args

--- a/source/GitWebLinks/Links/Handlers/LineSelection.vb
+++ b/source/GitWebLinks/Links/Handlers/LineSelection.vb
@@ -3,8 +3,8 @@ Public Class LineSelection
     Public Sub New(
             startLineNumber As Integer,
             endLineNumber As Integer,
-            startColumnNumber As Integer,
-            endColumnNumber As Integer
+            Optional startColumnNumber As Integer = 0,
+            Optional endColumnNumber As Integer = 0
         )
 
         Me.StartLineNumber = startLineNumber

--- a/source/GitWebLinks/Links/Handlers/LineSelection.vb
+++ b/source/GitWebLinks/Links/Handlers/LineSelection.vb
@@ -1,12 +1,16 @@
-﻿Public Class LineSelection
+Public Class LineSelection
 
     Public Sub New(
             startLineNumber As Integer,
-            endLineNumber As Integer
+            endLineNumber As Integer,
+            startColumnNumber As Integer,
+            endColumnNumber As Integer
         )
 
         Me.StartLineNumber = startLineNumber
         Me.EndLineNumber = endLineNumber
+        Me.StartColumnNumber = startColumnNumber
+        Me.EndColumnNumber = endColumnNumber
     End Sub
 
 
@@ -15,4 +19,7 @@
 
     Public ReadOnly Property EndLineNumber As Integer
 
+    Public ReadOnly Property StartColumnNumber As Integer
+
+    Public ReadOnly Property EndColumnNumber As Integer
 End Class

--- a/source/GitWebLinks/Links/Handlers/LineSelection.vb
+++ b/source/GitWebLinks/Links/Handlers/LineSelection.vb
@@ -3,8 +3,8 @@ Public Class LineSelection
     Public Sub New(
             startLineNumber As Integer,
             endLineNumber As Integer,
-            Optional startColumnNumber As Integer = 0,
-            Optional endColumnNumber As Integer = 0
+            startColumnNumber As Integer,
+            endColumnNumber As Integer
         )
 
         Me.StartLineNumber = startLineNumber
@@ -19,7 +19,10 @@ Public Class LineSelection
 
     Public ReadOnly Property EndLineNumber As Integer
 
+
     Public ReadOnly Property StartColumnNumber As Integer
 
+
     Public ReadOnly Property EndColumnNumber As Integer
+
 End Class

--- a/tests/GitWebLinks.Tests/Commands/CopyLinkToCurrentFileCommandTests.vb
+++ b/tests/GitWebLinks.Tests/Commands/CopyLinkToCurrentFileCommandTests.vb
@@ -105,7 +105,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
 
             dte = MockDte(
-                selection:=New LineSelection(3, 3, 3, 3)
+                selection:=New LineSelection(3, 3)
             )
 
             handler = New Mock(Of ILinkHandler)
@@ -135,7 +135,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
 
             dte = MockDte(
-                selection:=New LineSelection(3, 4, 3, 3)
+                selection:=New LineSelection(3, 4)
             )
 
             handler = New Mock(Of ILinkHandler)
@@ -205,7 +205,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
             dte = MockDte(
                 activeFileName:="Z:\foo\bar.txt",
-                selection:=New LineSelection(34, 34, 3, 3)
+                selection:=New LineSelection(34, 34)
             )
 
             gitInfo = New GitInfo("a", "b")
@@ -243,7 +243,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
             dte = MockDte(
                 activeFileName:="Z:\foo\bar.txt",
-                selection:=New LineSelection(21, 38, 3, 3)
+                selection:=New LineSelection(21, 38)
             )
 
             gitInfo = New GitInfo("a", "b")
@@ -317,7 +317,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
 
         If selection Is Nothing Then
-            selection = New LineSelection(1, 1, 1, 1)
+            selection = New LineSelection(1, 1)
         End If
 
         textSelection = New Mock(Of TextSelection)

--- a/tests/GitWebLinks.Tests/Commands/CopyLinkToCurrentFileCommandTests.vb
+++ b/tests/GitWebLinks.Tests/Commands/CopyLinkToCurrentFileCommandTests.vb
@@ -105,7 +105,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
 
             dte = MockDte(
-                selection:=New LineSelection(3, 3)
+                selection:=New LineSelection(3, 3, 3, 3)
             )
 
             handler = New Mock(Of ILinkHandler)
@@ -135,7 +135,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
 
             dte = MockDte(
-                selection:=New LineSelection(3, 4)
+                selection:=New LineSelection(3, 4, 3, 3)
             )
 
             handler = New Mock(Of ILinkHandler)
@@ -205,7 +205,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
             dte = MockDte(
                 activeFileName:="Z:\foo\bar.txt",
-                selection:=New LineSelection(34, 34)
+                selection:=New LineSelection(34, 34, 3, 3)
             )
 
             gitInfo = New GitInfo("a", "b")
@@ -243,7 +243,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
             dte = MockDte(
                 activeFileName:="Z:\foo\bar.txt",
-                selection:=New LineSelection(21, 38)
+                selection:=New LineSelection(21, 38, 3, 3)
             )
 
             gitInfo = New GitInfo("a", "b")
@@ -317,7 +317,7 @@ Public Class CopyLinkToCurrentFileCommandTests
 
 
         If selection Is Nothing Then
-            selection = New LineSelection(1, 1)
+            selection = New LineSelection(1, 1, 1, 1)
         End If
 
         textSelection = New Mock(Of TextSelection)

--- a/tests/GitWebLinks.Tests/Links/Handlers/AzureDevOpsHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/AzureDevOpsHandlerTests.vb
@@ -84,8 +84,8 @@ Public Class AzureDevOpsHandlerTests
                 End Using
 
                 Assert.Equal(
-                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Fsub%20dir%2Ffile.cs&version=GBmaster&line=2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
+                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Fsub%20dir%2Ffile.cs&version=GBmaster&line=2&lineStartColumn=2&lineEndColumn=2",
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 2, 2))
                 )
             End Using
         End Function
@@ -108,8 +108,8 @@ Public Class AzureDevOpsHandlerTests
                 End Using
 
                 Assert.Equal(
-                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
+                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=2&lineStartColumn=2&lineEndColumn=2",
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 2, 2))
                 )
             End Using
         End Function
@@ -132,8 +132,8 @@ Public Class AzureDevOpsHandlerTests
                 End Using
 
                 Assert.Equal(
-                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=1&lineEnd=3",
-                    handler.MakeUrl(info, fileName, New LineSelection(1, 3))
+                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=1&lineStartColumn=1&lineEndColumn=1&lineEnd=3",
+                    handler.MakeUrl(info, fileName, New LineSelection(1, 3, 1, 1))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/AzureDevOpsHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/AzureDevOpsHandlerTests.vb
@@ -84,8 +84,8 @@ Public Class AzureDevOpsHandlerTests
                 End Using
 
                 Assert.Equal(
-                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Fsub%20dir%2Ffile.cs&version=GBmaster&line=2&lineStartColumn=2&lineEndColumn=2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 2, 2))
+                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Fsub%20dir%2Ffile.cs&version=GBmaster",
+                    handler.MakeUrl(info, fileName, Nothing)
                 )
             End Using
         End Function
@@ -93,7 +93,7 @@ Public Class AzureDevOpsHandlerTests
 
         <Theory()>
         <MemberData(NameOf(GetRemotes), MemberType:=GetType(AzureDevOpsHandlerTests))>
-        Public Async Function CreatesCorrectLinkWithSingleLineSelection(remote As String) As Threading.Tasks.Task
+        Public Async Function CreatesCorrectLinkWithSingleLineSelectionWithNoWidth(remote As String) As Threading.Tasks.Task
             Using dir As New TempDirectory
                 Dim handler As AzureDevOpsHandler
                 Dim info As GitInfo
@@ -108,8 +108,32 @@ Public Class AzureDevOpsHandlerTests
                 End Using
 
                 Assert.Equal(
-                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=2&lineStartColumn=2&lineEndColumn=2",
+                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=2&lineEnd=3&lineStartColumn=1&lineEndColumn=1",
                     handler.MakeUrl(info, fileName, New LineSelection(2, 2, 2, 2))
+                )
+            End Using
+        End Function
+
+
+        <Theory()>
+        <MemberData(NameOf(GetRemotes), MemberType:=GetType(AzureDevOpsHandlerTests))>
+        Public Async Function CreatesCorrectLinkWithSingleLineSelectionWithNonZeroWidth(remote As String) As Threading.Tasks.Task
+            Using dir As New TempDirectory
+                Dim handler As AzureDevOpsHandler
+                Dim info As GitInfo
+                Dim fileName As String
+
+
+                info = New GitInfo(dir.FullPath, remote)
+                fileName = Path.Combine(dir.FullPath, "src\file.cs")
+                handler = Await CreateHandlerAsync()
+
+                Using LinkHandlerHelpers.InitializeRepository(dir.FullPath)
+                End Using
+
+                Assert.Equal(
+                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=2&lineEnd=5&lineStartColumn=6&lineEndColumn=9",
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 5, 6, 9))
                 )
             End Using
         End Function
@@ -132,8 +156,8 @@ Public Class AzureDevOpsHandlerTests
                 End Using
 
                 Assert.Equal(
-                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=1&lineStartColumn=1&lineEndColumn=1&lineEnd=3",
-                    handler.MakeUrl(info, fileName, New LineSelection(1, 3, 1, 1))
+                    "https://dev.azure.com/user/MyProject/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=1&lineEnd=3&lineStartColumn=6&lineEndColumn=11",
+                    handler.MakeUrl(info, fileName, New LineSelection(1, 3, 6, 11))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/BitbucketCloudHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/BitbucketCloudHandlerTests.vb
@@ -107,7 +107,7 @@ Public Class BitbucketCloudHandlerTests
 
                 Assert.Equal(
                     "https://bitbucket.org/atlassian/atlassian-bamboo_rest/src/master/lib/puppet/feature/restclient.rb#restclient.rb-2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
                 )
             End Using
         End Function
@@ -130,7 +130,7 @@ Public Class BitbucketCloudHandlerTests
 
                 Assert.Equal(
                     "https://bitbucket.org/atlassian/atlassian-bamboo_rest/src/master/lib/puppet/feature/restclient.rb#restclient.rb-1:3",
-                    handler.MakeUrl(info, fileName, New LineSelection(1, 3, 1, 1))
+                    handler.MakeUrl(info, fileName, New LineSelection(1, 3))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/BitbucketCloudHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/BitbucketCloudHandlerTests.vb
@@ -107,7 +107,7 @@ Public Class BitbucketCloudHandlerTests
 
                 Assert.Equal(
                     "https://bitbucket.org/atlassian/atlassian-bamboo_rest/src/master/lib/puppet/feature/restclient.rb#restclient.rb-2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
                 )
             End Using
         End Function
@@ -130,7 +130,7 @@ Public Class BitbucketCloudHandlerTests
 
                 Assert.Equal(
                     "https://bitbucket.org/atlassian/atlassian-bamboo_rest/src/master/lib/puppet/feature/restclient.rb#restclient.rb-1:3",
-                    handler.MakeUrl(info, fileName, New LineSelection(1, 3))
+                    handler.MakeUrl(info, fileName, New LineSelection(1, 3, 1, 1))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/BitbucketServerHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/BitbucketServerHandlerTests.vb
@@ -159,7 +159,7 @@ Public Class BitbucketServerHandlerTests
 
                 Assert.Equal(
                     "https://local-bitbucket:7990/context/projects/bb/repos/my-code/browse/lib/server/main.cs?at=refs%2Fheads%2Fmaster#2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
                 )
             End Using
         End Function
@@ -182,7 +182,7 @@ Public Class BitbucketServerHandlerTests
 
                 Assert.Equal(
                     "https://local-bitbucket:7990/context/projects/bb/repos/my-code/browse/lib/server/main.cs?at=refs%2Fheads%2Fmaster#10-23",
-                    handler.MakeUrl(info, fileName, New LineSelection(10, 23))
+                    handler.MakeUrl(info, fileName, New LineSelection(10, 23, 1, 1))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/BitbucketServerHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/BitbucketServerHandlerTests.vb
@@ -159,7 +159,7 @@ Public Class BitbucketServerHandlerTests
 
                 Assert.Equal(
                     "https://local-bitbucket:7990/context/projects/bb/repos/my-code/browse/lib/server/main.cs?at=refs%2Fheads%2Fmaster#2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
                 )
             End Using
         End Function
@@ -182,7 +182,7 @@ Public Class BitbucketServerHandlerTests
 
                 Assert.Equal(
                     "https://local-bitbucket:7990/context/projects/bb/repos/my-code/browse/lib/server/main.cs?at=refs%2Fheads%2Fmaster#10-23",
-                    handler.MakeUrl(info, fileName, New LineSelection(10, 23, 1, 1))
+                    handler.MakeUrl(info, fileName, New LineSelection(10, 23))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/GitHubHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/GitHubHandlerTests.vb
@@ -167,7 +167,7 @@ Public Class GitHubHandlerTests
 
                 Assert.Equal(
                     "https://github.com/dotnet/corefx/blob/master/src/System.IO.FileSystem/src/System/IO/Directory.cs#L38",
-                    handler.MakeUrl(info, fileName, New LineSelection(38, 38))
+                    handler.MakeUrl(info, fileName, New LineSelection(38, 38, 1, 1))
                 )
             End Using
         End Function
@@ -190,7 +190,7 @@ Public Class GitHubHandlerTests
 
                 Assert.Equal(
                     "https://github.com/dotnet/corefx/blob/master/src/System.IO.FileSystem/src/System/IO/Directory.cs#L38-L49",
-                    handler.MakeUrl(info, fileName, New LineSelection(38, 49))
+                    handler.MakeUrl(info, fileName, New LineSelection(38, 49, 1, 1))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/GitHubHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/GitHubHandlerTests.vb
@@ -167,7 +167,7 @@ Public Class GitHubHandlerTests
 
                 Assert.Equal(
                     "https://github.com/dotnet/corefx/blob/master/src/System.IO.FileSystem/src/System/IO/Directory.cs#L38",
-                    handler.MakeUrl(info, fileName, New LineSelection(38, 38, 1, 1))
+                    handler.MakeUrl(info, fileName, New LineSelection(38, 38))
                 )
             End Using
         End Function
@@ -190,7 +190,7 @@ Public Class GitHubHandlerTests
 
                 Assert.Equal(
                     "https://github.com/dotnet/corefx/blob/master/src/System.IO.FileSystem/src/System/IO/Directory.cs#L38-L49",
-                    handler.MakeUrl(info, fileName, New LineSelection(38, 49, 1, 1))
+                    handler.MakeUrl(info, fileName, New LineSelection(38, 49))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/VisualStudioTeamServicesHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/VisualStudioTeamServicesHandlerTests.vb
@@ -108,7 +108,7 @@ Public Class VisualStudioTeamServicesHandlerTests
 
                 Assert.Equal(
                     "https://foo.visualstudio.com/_git/MyRepo?path=%2Fsrc%2Fsub%20dir%2Ffile.cs&version=GBmaster&line=2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
                 )
             End Using
         End Function
@@ -131,7 +131,7 @@ Public Class VisualStudioTeamServicesHandlerTests
 
                 Assert.Equal(
                     "https://foo.visualstudio.com/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
                 )
             End Using
         End Function
@@ -154,7 +154,7 @@ Public Class VisualStudioTeamServicesHandlerTests
 
                 Assert.Equal(
                     "https://foo.visualstudio.com/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=1&lineEnd=3",
-                    handler.MakeUrl(info, fileName, New LineSelection(1, 3))
+                    handler.MakeUrl(info, fileName, New LineSelection(1, 3, 0, 0))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/VisualStudioTeamServicesHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/VisualStudioTeamServicesHandlerTests.vb
@@ -108,7 +108,7 @@ Public Class VisualStudioTeamServicesHandlerTests
 
                 Assert.Equal(
                     "https://foo.visualstudio.com/_git/MyRepo?path=%2Fsrc%2Fsub%20dir%2Ffile.cs&version=GBmaster&line=2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
                 )
             End Using
         End Function
@@ -131,7 +131,7 @@ Public Class VisualStudioTeamServicesHandlerTests
 
                 Assert.Equal(
                     "https://foo.visualstudio.com/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
                 )
             End Using
         End Function
@@ -154,7 +154,7 @@ Public Class VisualStudioTeamServicesHandlerTests
 
                 Assert.Equal(
                     "https://foo.visualstudio.com/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=1&lineEnd=3",
-                    handler.MakeUrl(info, fileName, New LineSelection(1, 3))
+                    handler.MakeUrl(info, fileName, New LineSelection(1, 3, 1, 1))
                 )
             End Using
         End Function

--- a/tests/GitWebLinks.Tests/Links/Handlers/VisualStudioTeamServicesHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/VisualStudioTeamServicesHandlerTests.vb
@@ -108,7 +108,7 @@ Public Class VisualStudioTeamServicesHandlerTests
 
                 Assert.Equal(
                     "https://foo.visualstudio.com/_git/MyRepo?path=%2Fsrc%2Fsub%20dir%2Ffile.cs&version=GBmaster&line=2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
                 )
             End Using
         End Function
@@ -131,7 +131,7 @@ Public Class VisualStudioTeamServicesHandlerTests
 
                 Assert.Equal(
                     "https://foo.visualstudio.com/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=2",
-                    handler.MakeUrl(info, fileName, New LineSelection(2, 2, 1, 1))
+                    handler.MakeUrl(info, fileName, New LineSelection(2, 2))
                 )
             End Using
         End Function
@@ -154,7 +154,7 @@ Public Class VisualStudioTeamServicesHandlerTests
 
                 Assert.Equal(
                     "https://foo.visualstudio.com/_git/MyRepo?path=%2Fsrc%2Ffile.cs&version=GBmaster&line=1&lineEnd=3",
-                    handler.MakeUrl(info, fileName, New LineSelection(1, 3, 1, 1))
+                    handler.MakeUrl(info, fileName, New LineSelection(1, 3))
                 )
             End Using
         End Function


### PR DESCRIPTION
In reference to #6 
Added support for Azure Devops links to include the lineStartColumn and lineEndColumn querystring parameters so that highlighted code will persist and scroll to when the link is viewed in Azure DevOps 