### PR TITLE
fixes for Bitbucket Server and Github Enterprise settings

### DIFF
--- a/source/GitWebLinks/GitWebLinks.vbproj
+++ b/source/GitWebLinks/GitWebLinks.vbproj
@@ -53,6 +53,7 @@
     <DefineTrace>true</DefineTrace>
     <ErrorReport>prompt</ErrorReport>
     <NoWarn>41999,42016,42017,42018,42019,42020,42021,42022,42032,42036,42353,42354,42355</NoWarn>
+    <StartArguments>/rootsuffix Exp</StartArguments>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/source/GitWebLinks/Links/Handlers/BitbucketServerHandler.vb
+++ b/source/GitWebLinks/Links/Handlers/BitbucketServerHandler.vb
@@ -11,7 +11,7 @@ Public Class BitbucketServerHandler
 
     Public Overrides ReadOnly Property Name As String
         Get
-            Return "Bitbucket"
+            Return "Bitbucket Server"
         End Get
     End Property
 

--- a/source/GitWebLinks/Links/Handlers/LinkHandlerBase.vb
+++ b/source/GitWebLinks/Links/Handlers/LinkHandlerBase.vb
@@ -159,8 +159,8 @@ Public MustInherit Class LinkHandlerBase
 
         Return (
             From server In GetServerUrls()
-            Where remoteUrl.StartsWith(server.BaseUrl, StringComparison.Ordinal) _
-            OrElse remoteUrl.StartsWith(server.SshUrl, StringComparison.Ordinal)
+            Where (Not String.IsNullOrEmpty(server.BaseUrl) AndAlso remoteUrl.StartsWith(server.BaseUrl, StringComparison.Ordinal)) _
+            OrElse (Not String.IsNullOrEmpty(server.SshUrl) AndAlso remoteUrl.StartsWith(server.SshUrl, StringComparison.Ordinal))
         ).FirstOrDefault()
     End Function
 

--- a/source/GitWebLinks/Options/Options.vb
+++ b/source/GitWebLinks/Options/Options.vb
@@ -134,6 +134,7 @@ Public Class Options
             <servers>
                 <%=
                     From server In servers
+                    Where Not String.IsNullOrEmpty(server.BaseUrl) Or Not String.IsNullOrEmpty(server.SshUrl)
                     Select <server base=<%= server.BaseUrl %> ssh=<%= server.SshUrl %>/>
                 %>
             </servers>

--- a/tests/GitWebLinks.Tests/GitWebLinks.Tests.vbproj
+++ b/tests/GitWebLinks.Tests/GitWebLinks.Tests.vbproj
@@ -167,6 +167,7 @@
     <Compile Include="Links\Handlers\GitHubHandlerTests.vb" />
     <Compile Include="Links\Handlers\LinkHandlerHelpers.vb" />
     <Compile Include="My Project\AssemblyInfo.vb" />
+    <Compile Include="Options\OptionsTests.vb" />
     <Compile Include="Test Helpers\TempDirectory.vb" />
     <Compile Include="Test Helpers\TestAsyncServiceProvider.vb" />
   </ItemGroup>

--- a/tests/GitWebLinks.Tests/Links/Handlers/BitbucketServerHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/BitbucketServerHandlerTests.vb
@@ -8,7 +8,7 @@ Public Class BitbucketServerHandlerTests
 
         <Fact()>
         Public Async Function ReturnsBitbucket() As Threading.Tasks.Task
-            Assert.Equal("Bitbucket", (Await CreateHandlerAsync()).Name)
+            Assert.Equal("Bitbucket Server", (Await CreateHandlerAsync()).Name)
         End Function
 
     End Class
@@ -25,6 +25,26 @@ Public Class BitbucketServerHandlerTests
             handler = Await CreateHandlerAsync({New ServerUrl("https://local-bitbucket:7990/context", "git@local-bitbucket:7999")})
 
             Assert.True(handler.IsMatch(remote))
+        End Function
+
+        <Fact()>
+        Public Async Function MatchServerUrlsNotInSettingsEmptySsh() As Threading.Tasks.Task
+            Dim handler As BitbucketServerHandler
+
+
+            handler = Await CreateHandlerAsync({New ServerUrl("https://local-bitbucket:7990/context", Nothing)})
+
+            Assert.True(handler.IsMatch(GetHttpsRemoteUrl()))
+        End Function
+
+        <Fact()>
+        Public Async Function MatchServerUrlsNotInSettingsEmptyBaseUrl() As Threading.Tasks.Task
+            Dim handler As BitbucketServerHandler
+
+
+            handler = Await CreateHandlerAsync({New ServerUrl(Nothing, "git@local-bitbucket:7999")})
+
+            Assert.True(handler.IsMatch(GetGitRemoteUrl()))
         End Function
 
 

--- a/tests/GitWebLinks.Tests/Links/Handlers/GitHubHandlerTests.vb
+++ b/tests/GitWebLinks.Tests/Links/Handlers/GitHubHandlerTests.vb
@@ -41,6 +41,26 @@ Public Class GitHubHandlerTests
             Assert.True(handler.IsMatch(remote))
         End Function
 
+        <Fact()>
+        Public Async Function MatchServerUrlsNotInSettingsEmptySsh() As Threading.Tasks.Task
+            Dim handler As GitHubHandler
+
+
+            handler = Await CreateHandlerAsync({New ServerUrl("https://local-github", Nothing)})
+
+            Assert.True(handler.IsMatch("https://local-github/dotnet/corefx.git"))
+        End Function
+
+        <Fact()>
+        Public Async Function MatchServerUrlsNotInSettingsEmptyBaseUrl() As Threading.Tasks.Task
+            Dim handler As GitHubHandler
+
+
+            handler = Await CreateHandlerAsync({New ServerUrl(Nothing, "git@local-github")})
+
+            Assert.True(handler.IsMatch("ssh://git@local-github:dotnet/corefx.git"))
+        End Function
+
 
         <Fact()>
         Public Async Function DoesNotMatchServerUrlsNotInSettings() As Threading.Tasks.Task

--- a/tests/GitWebLinks.Tests/Options/OptionsTests.vb
+++ b/tests/GitWebLinks.Tests/Options/OptionsTests.vb
@@ -1,0 +1,17 @@
+Public Class OptionsTests
+    <Fact()>
+    Public Async Sub SaveServersWithEmptyBaseAndSsh()
+        Dim options As New Options()
+        Dim asyncServiceProvider As New TestAsyncServiceProvider()
+        Dim mocksettingsManager As New Mock(Of ISettingsManager)
+        asyncServiceProvider.AddService(mocksettingsManager.Object)
+        Await options.InitializeAsync(asyncServiceProvider)
+        options.BitbucketServerUrls = New List(Of ServerUrl) From {
+            New ServerUrl(Nothing, Nothing)
+        }
+
+        options.Save()
+
+        mocksettingsManager.Verify(Sub(x) x.SetString(It.Is(Function(n As String) n = "BitbucketServerServers"), It.Is(Function(v As String) v = "<servers />")), Times.Once())
+    End Sub
+End Class


### PR DESCRIPTION
fix issue when having empty BaseUrl or SshUrl in Bitbucket Server or Github Enterprise settings crashes extension

+ add null or empty check in GetMatchingServerUrl
+ save servers urls only if either BaseUrl or SshUrl not empty
+ change name to Bitbucket Server
+ run experimental instance of Visual Studio to allow debugging